### PR TITLE
Check for running transitions, extra options for writing numbers

### DIFF
--- a/library.json
+++ b/library.json
@@ -20,5 +20,12 @@
 	"avr",
     "esp8266",
 	"esp32"
+  ],
+  "dependencies":
+  [
+    {
+      "name": "FastLED",
+      "version": "^3.3.3"
+    }
   ]
 }

--- a/library.json
+++ b/library.json
@@ -24,7 +24,8 @@
   "dependencies":
   [
     {
-      "name": "fastled/FastLED",
+      "owner": "fastled",
+      "name": "FastLED",
       "version": "^3.3.3"
     }
   ]

--- a/library.json
+++ b/library.json
@@ -24,7 +24,7 @@
   "dependencies":
   [
     {
-      "name": "FastLED",
+      "name": "fastled/FastLED",
       "version": "^3.3.3"
     }
   ]

--- a/src/Lixie_II.cpp
+++ b/src/Lixie_II.cpp
@@ -118,7 +118,7 @@ void animate(){
 	}
   }
       
-  lix_controller->showLeds(); 
+  lix_controller->showLeds(255); 
 
   if(mask_fade_finished){
 		transition_running = false;
@@ -592,7 +592,7 @@ void Lixie_II::streak(CRGB col, float pos, uint8_t blur){
     
     lix_leds[i] = CRGB(col.r * pos_level, col.g * pos_level, col.b * pos_level);
   }
-  lix_controller->showLeds();
+  lix_controller->showLeds(255);
 }
 
 void Lixie_II::sweep_color(CRGB col, uint16_t speed, uint8_t blur, bool reverse){

--- a/src/Lixie_II.cpp
+++ b/src/Lixie_II.cpp
@@ -696,7 +696,7 @@ void Lixie_II::show(){
   mask_update();
 }
 
-bool Lixie_II::is_transitioning(){
+bool Lixie_II::is_transitioning() const{
 	return transition_running;
 }
 

--- a/src/Lixie_II.h
+++ b/src/Lixie_II.h
@@ -44,7 +44,7 @@ class Lixie_II
 		void sweep_gradient(CRGB col_left, CRGB col_right, uint16_t speed, uint8_t blur, bool reverse);
 		void start_animation();
 		void stop_animation();
-		void write(uint32_t input);
+		void write(uint32_t input, bool pad = false, bool skip_display = false);
 		void write_float(float input, uint8_t dec_places = 1);
 		void clear_all();
 		void write_digit(uint8_t digit, uint8_t num);
@@ -52,6 +52,9 @@ class Lixie_II
 		void clear_digit(uint8_t digit, uint8_t num);
 		void mask_update();
 		
+		// check if an transition animation is currently running (i.e. not yet finished) in 
+		// the background
+		bool is_transitioning();
 	private:
 		uint8_t get_size(uint32_t input);
 };


### PR DESCRIPTION
I've added a new function to check if a transition is running in the background. This is needed for example when the controller should enter a low power state after updating the display. The new function allows to check if a transition is still ongoing, allowing to enter the sleep state only after it's finished. Without this, the transistion would be interrupted prematurely.

Also related to low power states, I've added a new flag `skip_display` to the `write(...)` function which allows to set the internal state of the library class without actually updating the physical LEDs. When a program returns from certain low power states, the library needs to be initialized again as RAM content is not stored. In this case, the first time a number is displayed after the wakeup, the library would assume an empty display as starting point for the transition to the new display, causing the Lixie to flicker once. The new parameter allows to restore the internal state of the library required for a proper transition with minimal effort by invoking `write(...)` with the last displayed number and `skip_display = true` after wakeup and before writing the actual new value.

Last, I've added a parameter to pad written numbers with leading zeros. This is useful for example when using Lixies as a clock, to be able to directly write `0034` to display the time 00:34 and have all Lixies lit.